### PR TITLE
RSEF-13: Update PaperObj

### DIFF
--- a/src/RSEF/__main__.py
+++ b/src/RSEF/__main__.py
@@ -57,7 +57,7 @@ def cli():
 @click.option('--output', '-o', default="output", show_default=True, help="Output csv file", metavar='<path>')
 @click.option('--unidir', '-U', is_flag=True, default = False, help="Unidirectionality")
 @click.option('--bidir', '-B', is_flag=True, default = False, help="Bidirectionality")
-def assess(input, output, unidir, bidir, both):
+def assess(input, output, unidir, bidir):
     from .object_creator.pipeline import dois_txt_to_unidir_json, dois_txt_to_bidir_json, single_doi_pipeline_unidir, \
         single_doi_pipeline_bidir, papers_json_to_unidir_json, papers_json_to_bidir_json
     if unidir:

--- a/src/RSEF/__main__.py
+++ b/src/RSEF/__main__.py
@@ -57,7 +57,7 @@ def cli():
 @click.option('--output', '-o', default="output", show_default=True, help="Output csv file", metavar='<path>')
 @click.option('--unidir', '-U', is_flag=True, default = False, help="Unidirectionality")
 @click.option('--bidir', '-B', is_flag=True, default = False, help="Bidirectionality")
-def assess(input, output, unidir, bidir):
+def assess(input, output, unidir, bidir, both):
     from .object_creator.pipeline import dois_txt_to_unidir_json, dois_txt_to_bidir_json, single_doi_pipeline_unidir, \
         single_doi_pipeline_bidir, papers_json_to_unidir_json, papers_json_to_bidir_json
     if unidir:
@@ -67,17 +67,14 @@ def assess(input, output, unidir, bidir):
             papers_json_to_unidir_json(papers_json=input, output_dir=output)
             return
         else:
-            repo_link = single_doi_pipeline_unidir(doi=input,output_dir=output)
-            return repo_link
-
+            return single_doi_pipeline_unidir(doi=input,output_dir=output)
     elif bidir:
         if input.endswith(".txt") and os.path.exists(input):
             dois_txt_to_bidir_json(dois_txt=input,output_dir=output)
         if input.endswith(".json") and os.path.exists(input):
             papers_json_to_bidir_json(papers_json=input, output_dir=output)
         else:
-            single_doi_pipeline_bidir(doi=input, output_dir=output)
-            return
+            return single_doi_pipeline_bidir(doi=input, output_dir=output)
     else:
         print("Please select a directionality to measure")
         print("-U is to assess Uni-directionality")

--- a/src/RSEF/extraction/paper_obj.py
+++ b/src/RSEF/extraction/paper_obj.py
@@ -1,9 +1,9 @@
+from ..object_creator.implementation_url import ImplementationUrl
 from ..utils.regex import str_to_doiID, str_to_arxivID
-
 class PaperObj:
-    def __init__(self, title, urls, doi, arxiv, abstract, file_name, file_path):
+    def __init__(self, title, implementation_urls, doi, arxiv, abstract, file_name, file_path):
         self._title = title
-        self._urls = urls
+        self._implementation_urls = implementation_urls
         self._doi = str_to_doiID(doi)
         self._arxiv = str_to_arxivID(arxiv)
         self._file_name = file_name
@@ -19,12 +19,32 @@ class PaperObj:
         self._title = value
 
     @property
-    def urls(self):
-        return self._urls
+    def implementation_urls(self):
+        return self._implementation_urls
 
-    @urls.setter
-    def urls(self, value):
-        self._urls = value
+    @implementation_urls.setter
+    def implementation_urls(self, value):
+        self._implementation_urls = value
+
+    def add_implementation_link(self, url, url_type, source_paragraphs=[], extraction_method='regex', frequency=1):
+        duplicate = False
+        # Look for the url in the list of implementation urls
+        for implementation_url in self._implementation_urls:
+            if implementation_url.url == url:
+                # Append the extraction method to the list of extraction methods
+                implementation_url.extraction_method.append(extraction_method)
+                
+                # If source paragraphs are provided, append them to the list of source paragraphs
+                if source_paragraphs:
+                    implementation_url.source_paragraphs.extend(source_paragraphs)
+                    
+                duplicate = True
+                break
+            
+        # If the url is not in the list of implementation urls, add it
+        if not duplicate:
+            implementation_url = ImplementationUrl(url=url, url_type=url_type, extraction_method=[extraction_method], source_paragraphs=source_paragraphs, frequency=frequency)
+            self._implementation_urls.append(url)
 
     @property
     def abstract(self):
@@ -69,7 +89,7 @@ class PaperObj:
     def to_dict(self):
         return {
             'title': self._title,
-            'urls': self._urls,
+            'implementation_urls': [url.to_dict() for url in self._implementation_urls],
             'doi': self._doi,
             'arxiv': self._arxiv,
             'abstract': self._abstract,

--- a/src/RSEF/object_creator/implementation_url.py
+++ b/src/RSEF/object_creator/implementation_url.py
@@ -1,0 +1,67 @@
+class ImplementationUrl:
+    def __init__(self, url, url_type, frequency, extraction_method, source_paragraphs):
+        self.url = url
+        self.url_type = url_type
+        self.frequency = frequency
+        self.extraction_method = extraction_method
+        self.source_paragraphs = source_paragraphs
+
+    def __str__(self):
+        return "URL: %s\nURL Type: %s\nFrequency: %s\nextraction_method: %s\nSource Paragraph: %s\n" % \
+                (self.url, self.url_type, self.frequency, self.extraction_method, self.source_paragraphs)
+
+    def __repr__(self):
+        return self.__str__()
+
+    @property
+    def url(self):
+        return self._url
+
+    @url.setter
+    def url(self, value):
+        self._url = value
+
+    @property
+    def url_type(self):
+        return self._url_type
+    
+    @url_type.setter
+    def url_type(self, value):
+        self._url_type = value
+
+    @property
+    def frequency(self):
+        return self._frequency
+
+    @frequency.setter
+    def frequency(self, value):
+        self._frequency = value
+
+    @property
+    def extraction_method(self):
+        return self._extraction_method
+
+    @extraction_method.setter
+    def extraction_method(self, value):
+        self._extraction_method = value
+
+    @property
+    def source_paragraphs(self):
+        return self._source_paragraphs
+
+    @source_paragraphs.setter
+    def source_paragraphs(self, value):
+        self._source_paragraphs = value
+
+    def to_dict(self):
+        return {
+            "url": self.url, 
+            "url_type": self.url_type,
+            "frequency": self.frequency, 
+            "extraction_method": self.extraction_method, 
+            "source_paragraphs": self.source_paragraphs
+        }
+
+    @staticmethod
+    def from_dict(dic):
+        return ImplementationUrl(url=dic["url"], url_type=dic["url_type"], frequency=dic["frequency"], extraction_method=dic["extraction_method"], source_paragraphs=dic["source_paragraphs"])

--- a/src/RSEF/object_creator/paper_obj_utils.py
+++ b/src/RSEF/object_creator/paper_obj_utils.py
@@ -10,7 +10,7 @@ def paperDict_to_paperObj(paper_dict):
     file_path = safe_dic(paper_dict,"file_path")
     urls = safe_dic(paper_dict,"urls")
     abstract = safe_dic(paper_dict,"abstract")
-    return PaperObj(title=title, urls=urls, doi=doi, arxiv=arxiv, file_name=file_name, file_path=file_path, abstract=abstract)
+    return PaperObj(title=title, implementation_urls=urls, doi=doi, arxiv=arxiv, file_name=file_name, file_path=file_path, abstract=abstract)
 
 
 def safe_dic(dic, key):

--- a/src/RSEF/object_creator/pipeline.py
+++ b/src/RSEF/object_creator/pipeline.py
@@ -42,8 +42,7 @@ def single_doi_pipeline_bidir(doi, output_dir):
     dictionary with doi and the urls found that are bidirectional for that doi
     """
     paper = doi_to_paper(doi,output_dir)
-    result = check_bidir(paper,output_dir)
-    return result
+    return check_bidir(paper,output_dir)
 
 
 def single_doi_pipeline_unidir(doi, output_dir):
@@ -57,8 +56,10 @@ def single_doi_pipeline_unidir(doi, output_dir):
     if not paper:
         print("Error while creating paperObj")
         return None
-    repo_link = extract_repo_links_from_pdf(paper.file_path)
-    return repo_link
+    repo_link, source_para = extract_repo_links_from_pdf(paper.file_path)
+    if repo_link:
+        paper.add_implementation_link(repo_link, 'git', source_paragraphs=[source_para], extraction_method='unidir')
+    return paper
 
 
 def single_pdf_pipeline_single_bidir(pdf, output_dir):

--- a/src/RSEF/repofrompaper/rfp.py
+++ b/src/RSEF/repofrompaper/rfp.py
@@ -58,4 +58,4 @@ def extract_repo_links_from_pdf(pdf_path: str) -> Tuple[List[str], str]:
                 all_footnotes, sentences, best_sentences)
             link = find_link_in_sentences(sentences_with_footnote)
 
-    return clean_final_link(link)
+    return clean_final_link(link), 'sample source paragraph' # TODO: Implement source paragraph extraction


### PR DESCRIPTION
This PR addresses [Issue 13](https://github.com/SoftwareUnderstanding/RSEF/issues/13) with the main changes being restructuring of the PaperObj class. A new class "ImplementationUrl" is introduced in order to better represent the extracted urls and their metadata.

The "single_doi_pipeline_unidir" and "single_doi_pipeline_bidir" now return the PaperObj with the updated ImplementationUrls (if found).