### PR TITLE
RSEF-11: Update Output Format

### DIFF
--- a/src/RSEF/extraction/paper_obj.py
+++ b/src/RSEF/extraction/paper_obj.py
@@ -10,6 +10,12 @@ class PaperObj:
         self._file_path = file_path
         self._abstract = abstract
 
+    def __str__(self):
+        return f"Title: {self._title}\nImplementation URLs: {self._implementation_urls}\nDOI: {self._doi}\nArXiv: {self._arxiv}\nAbstract: {self._abstract}\nFile Name: {self._file_name}\nFile Path: {self._file_path}"
+
+    def __repr__(self):
+        return self.__str__()
+    
     @property
     def title(self):
         return self._title


### PR DESCRIPTION
This PR fixes #11 and is a continuation of #15.

-  The main changes in this PR a unified output format for all functions that can be called through the `RSEF asses` command. The output format follows the guidelines defined in the issue related to #15. 
-  This PR allows sequential running of a bidir and unidir search from the same command.
- Multiple functions are refactored in the `pipeline.py` file in order to avoid code duplication.

