### PR TITLE
RSEF-20: Retrieve source paragraphs

### DIFF
--- a/src/RSEF/extraction/paper_obj.py
+++ b/src/RSEF/extraction/paper_obj.py
@@ -50,7 +50,7 @@ class PaperObj:
         # If the url is not in the list of implementation urls, add it
         if not duplicate:
             implementation_url = ImplementationUrl(url=url, url_type=url_type, extraction_method=[extraction_method], source_paragraphs=source_paragraphs, frequency=frequency)
-            self._implementation_urls.append(url)
+            self._implementation_urls.append(implementation_url)
 
     @property
     def abstract(self):

--- a/src/RSEF/repofrompaper/link_search.py
+++ b/src/RSEF/repofrompaper/link_search.py
@@ -21,7 +21,7 @@ def find_link_in_references(reference_numbers: List[str], references: Dict[str, 
             if repo_links:
                 link = repo_links[0]
                 print(f'Found {link} in references dictionary using {ref} reference number')
-                return link, references[ref]
+                return link, ref
     return None, None
 
 

--- a/src/RSEF/repofrompaper/link_search.py
+++ b/src/RSEF/repofrompaper/link_search.py
@@ -21,8 +21,8 @@ def find_link_in_references(reference_numbers: List[str], references: Dict[str, 
             if repo_links:
                 link = repo_links[0]
                 print(f'Found {link} in references dictionary using {ref} reference number')
-                return link
-    return None
+                return link, references[ref]
+    return None, None
 
 
 def find_link_in_footnotes(all_footnotes: List[str], footnotes: Dict[str, str]) -> Optional[str]:
@@ -32,25 +32,25 @@ def find_link_in_footnotes(all_footnotes: List[str], footnotes: Dict[str, str]) 
         if f in footnotes:
             link = footnotes[f]
             print(f'Found {link} in footnotes dictionary using footnote {f}')
-            return link
-    return None
+            return link, f
+    return None, None
 
 
 def find_link_in_sentences(sentences_with_footnote: List[Tuple[str, str]]) -> Optional[str]:
     """Find the link in the sentences with footnote for the given footnotes"""
     # Look for link attached to the footnote in sentence
-    for sentence_with_number, footnote_link in sentences_with_footnote:
+    for sentence_with_number, footnote_link, footnote in sentences_with_footnote:
         if footnote_link:
             link = footnote_link
-            return link
+            return link, footnote
 
     # Look for sentence that contains the footnote
-    for sentence_with_number, footnote_link in sentences_with_footnote:
+    for sentence_with_number, footnote_link, footnote in sentences_with_footnote:
         repo_links = find_repo_links(sentence_with_number)
         if repo_links:
             link = repo_links[0]
-            return link
-    return None
+            return link, footnote
+    return None, None
 
 
 def extract_link_by_number(sentence: str, target_number: str) -> str:
@@ -75,6 +75,6 @@ def get_sentences_with_footnote(footnotes: List[str], sentences: List[str], best
                     and ('github' in sentence or 'gitlab' in sentence) \
                     and sentence not in best_sentences:
                 link = extract_link_by_number(sentence, str(footnote))
-                sentences_with_footnote.append((sentence, link))
+                sentences_with_footnote.append((sentence, link, str(footnote)))
 
     return sentences_with_footnote

--- a/src/RSEF/repofrompaper/rfp.py
+++ b/src/RSEF/repofrompaper/rfp.py
@@ -51,11 +51,14 @@ def extract_repo_links_from_pdf(pdf_path: str) -> Tuple[List[str], str]:
             number_sources[sentence] = {'footnotes': numbers+extra_chars, 'references': square_brackets}
 
     if not link and reference_numbers:  # No link found in best matches, look for references or footnotes
-        link, reference = find_link_in_references(reference_numbers, references)
+        link, ref = find_link_in_references(reference_numbers, references)
         
         # If the link is found, store the source paragraph by looking for the reference number
-        if link and reference:
-            source_para = reference
+        if link and ref:
+            for key, value in number_sources.items():
+                if ref in value['references']:
+                    source_para = key
+                    break               
 
     if not link and all_footnotes:
         # Remove duplicates in all_footnotes while keeping order

--- a/src/RSEF/repofrompaper/rfp.py
+++ b/src/RSEF/repofrompaper/rfp.py
@@ -17,6 +17,7 @@ def extract_repo_links_from_pdf(pdf_path: str) -> Tuple[List[str], str]:
     best_sentences = get_top_sentences(sentences)
 
     link, all_footnotes, reference_numbers = '', [], []
+    source_para, number_sources = '', {}
 
     for sentence in best_sentences:
         # Look for github links
@@ -24,6 +25,7 @@ def extract_repo_links_from_pdf(pdf_path: str) -> Tuple[List[str], str]:
 
         if repo_links:
             link = repo_links[0]
+            source_para = sentence
             break
         else:
             # Use regular expression to find numbers attached to words
@@ -44,18 +46,32 @@ def extract_repo_links_from_pdf(pdf_path: str) -> Tuple[List[str], str]:
             # Use regular expression to find special characters used as footnotes
             extra_chars = list(set(re.findall(r'[†‡*]', sentence)))
             all_footnotes.extend(numbers+extra_chars)
+            
+            # Store the sentence and its footnotes and references
+            number_sources[sentence] = {'footnotes': numbers+extra_chars, 'references': square_brackets}
 
     if not link and reference_numbers:  # No link found in best matches, look for references or footnotes
-        link = find_link_in_references(reference_numbers, references)
+        link, reference = find_link_in_references(reference_numbers, references)
+        
+        # If the link is found, store the source paragraph by looking for the reference number
+        if link and reference:
+            source_para = reference
 
     if not link and all_footnotes:
         # Remove duplicates in all_footnotes while keeping order
         all_footnotes = list(dict.fromkeys(all_footnotes))
-        link = find_link_in_footnotes(all_footnotes, footnotes)
+        link, footnote = find_link_in_footnotes(all_footnotes, footnotes)
 
         if not link:
             sentences_with_footnote = get_sentences_with_footnote(
                 all_footnotes, sentences, best_sentences)
-            link = find_link_in_sentences(sentences_with_footnote)
-
-    return clean_final_link(link), 'sample source paragraph' # TODO: Implement source paragraph extraction
+            link, footnote = find_link_in_sentences(sentences_with_footnote)
+            
+        # If the link is found, store the source paragraph by looking for the footnote number
+        if link and footnote:
+            for key, value in number_sources.items():
+                if footnote in value['footnotes']:
+                    source_para = key
+                    break
+                
+    return clean_final_link(link), source_para


### PR DESCRIPTION
Fixes #20 
---

This PR retrieves the source paragraphs where the URL was found in the RepoFromPaper pipeline. 

1. In case of in-line text mentions, the sentence is returned.
2. In case of footnotes, the sentence where the footnote number is found is returned.
3. In case of references, the sentence where the reference number is found is returned.