### PR TITLE
RSEF-37: Serial processing improvement

### DIFF
--- a/doc/JSONs.md
+++ b/doc/JSONs.md
@@ -74,8 +74,6 @@ The `processed_metadata.json` file contains an array of objects, each representi
 ```"SOMEF"```means that for a GitHub repository found in the paper, the repository has been examined using SOMEF to search for citations or references to the paper. The analysis found a relationship between the paper and the repository, confirming a bidirectional relationship. This is only for bidirectional relationships.
 <br>
 
-## url_search_output.json
+## example.json
 
-The `url_search_output.json` file contains an array of objects, each representing a paper after searching for unidirectional links, bidirectional links, or both.
-
-The resulting JSON has the same structure as the `processed_metadata.json`
+The `example.json` file contains an array of objects, each representing the RSEF output of a paper after searching for unidirectional and bidirectional links.

--- a/doc/example.json
+++ b/doc/example.json
@@ -1,0 +1,99 @@
+{
+    "RSEF Output": [
+        {
+            "title": "Normalized Neural Representations of Complex Odors",
+            "implementation_urls": [
+                {
+                    "identifier": "https://github.com/david-zwicker/sensing-normalized-results",
+                    "type": "git",
+                    "paper_frequency": 2,
+                    "extraction_methods": [
+                        {
+                            "type": "unidir",
+                            "location": "output\\PDFs\\10!1371%journal!pone!0166456.pdf",
+                            "location_type": "PAPER",
+                            "source": "",
+                            "source_paragraph": "Data Availability Statement: The python source code to run the simulations and produce the figures of this paper is available at https://github.com/david-zwicker/sensing-normalized-results."
+                        }
+                    ]
+                }
+            ],
+            "doi": "10.1371/journal.pone.0166456",
+            "arxiv": "1608.01179",
+            "abstract": "AbstractThe olfactory system removes correlations in natural odors using a network of inhibitoryneurons in the olfactory bulb. It has been proposed that this network integrates the responsefrom all olfactory receptors and inhibits them equally. However, how such global inhibitioninfluences the neural representations of odors is unclear. Here, we study a simple statisticalmodel of the processing in the olfactory bulb, which leads to concentration-invariant, sparserepresentations of the odor composition. We show that the inhibition strength can be tunedto obtain sparse representations that are still useful to discriminate odors that vary in relativeconcentration, size, and composition. The model reveals two generic consequences ofglobal inhibition: (i) odors with many molecular species are more difficult to discriminate and(ii) receptor arrays with heterogeneous sensitivities perform badly. Comparing these predic-tions to experiments will help us to understand the role of global inhibition in shaping normal-ized odor representations in the olfactory bulb.IntroductionSensory systems encode information efficiently by removing redundancies present in naturalstimuli [1, 2]. In natural images, for instance, neighboring regions are likely of similar bright-ness and the image can thus be characterized by the regions of brightness changes [3]. Thisstructure is exploited by ganglion cells in the retina that respond to brightness gradients byreceiving excitatory input from photo receptors in one location and inhibitory input from thesurrounding [4]. This typical center-surround inhibition results in neural patterns that repre-sent natural images efficiently [5]. Similarly, such local inhibition helps separating sound fre-quencies in the ear and locations touched on the skin [6]. Vision, hearing, and touch have incommon that their stimulus spaces have a metric for which typical correlations in natural sti-muli are local. Consequently, local inhibition can be used to remove these correlations andreduce the high-dimensional input to a lower-dimensional representation.The olfactory stimulus space is also high-dimensional, since odors are comprised of manymolecules at different concentrations. Moreover, the concentrations are also often correlated,e.g., because the molecules originate from the same source. However, these correlations arePLOS ONE | DOI:10.1371/journal.pone.0166456 November 11, 2016 1 / 16a11111OPENACCESSCitation: Zwicker D (2016) Normalized NeuralRepresentations of Complex Odors. PLoS ONE11(11): e0166456. doi:10.1371/journal.pone.0166456Editor: Hiroaki Matsunami, Duke University,UNITED STATESReceived: August 18, 2016Accepted: October 29, 2016Published: November 11, 2016Copyright: © 2016 David Zwicker. This is an openaccess article distributed under the terms of theCreative Commons Attribution License, whichpermits unrestricted use, distribution, andreproduction in any medium, provided the originalauthor and source are credited.Data Availability Statement: The python sourcecode to run the simulations and produce thefigures of this paper is available at https://github.com/david-zwicker/sensing-normalized-results.",
+            "file_name": "10!1371%journal!pone!0166456.pdf",
+            "file_path": "output\\PDFs\\10!1371%journal!pone!0166456.pdf"
+        },
+        {
+            "title": "Speciation in a MacArthur model predicts growth, stability, and adaptation in ecosystem dynamics",
+            "implementation_urls": [
+                {
+                    "identifier": "https://doi.org/10.5281/zenodo.7164175",
+                    "type": "zenodo",
+                    "paper_frequency": 1,
+                    "extraction_methods": [
+                        {
+                            "type": "bidir",
+                            "location": "ZENODO",
+                            "location_type": "ARXIV",
+                            "source": "RSEF",
+                            "source_paragraph": ""
+                        }
+                    ]
+                }
+            ],
+            "doi": "10.1007/s12080-023-00564-2",
+            "arxiv": "1803.00487",
+            "abstract": "AbstractEcosystem dynamics is often considered driven by a coupling of species’ resource consumption and its population size dynamics. Such resource-population dynamics is captured by MacArthur-type models. One biologically relevant feature that would also need to be captured by such models is the introduction of new and different species. Speciation introduces a stochastic component in the otherwise deterministic MacArthur theory. We describe here how speciation can be implemented to yield a model that is consistent with current theory on equilibrium resource-consumer models, but also displays readily observable rank diversity metric changes. The model also reproduces a priority effect. Adding speciation to a MacArthur-style model provides an attractively simple extension to explore the rich dynamics in evolving ecosystems.Keywords Environmental stochasticity · Population dynamics · Evolution · CoexistenceIntroductionAn ecosystem is a set of species, each of finite population size that interact by competing for finite resources that fuel their growth. A single ecosystem can involve dynamics that occurs over a wide range of length and timescales (Azaele et al. 2016); Darwin already eloquently referred to this in his “tangled bank” remark. The seemingly universal nature of a species’ emergence, adaptation and extinction in such ecosystems, has inspired many to describe the phenomenol-ogy of ecosystem dynamics with simple modeling with only a few ingredients that are independent of the specific physi-cal mechanisms at play (Nowak 2006; Azaele et al. 2016). What is then the simplest quantitative description that dis-plays all the salient dynamical features of evolution? This question has a long list of partial answers (Nowak 2006; Tikhonov 2016; Posfai et al. 2017), although much work in the field concerns equilibria (MacArthur and Wilson 1963; MacArthur 1955; Chesson 1990; Hubbell 2001). Here, we show that the already successful variants of MacArthur models can be amended with a simple stochastic mechanism that introduces new species, which allows us to show many of the biologically relevant dynamical features of evolution even when the starting point for the dynamics is a single pri-mordial ancestor. In particular, our MacArthur model variant can describe the growth dynamics of an ecosystem in terms of species richness, its evolution towards a dynamic equilib-rium size, and even its adaptation to resource influx changes. The predictions of the model are consistent with other exist-ing modeling on, for example, equilibrium dynamics and reasonably in line with common observations on, for exam-ple, resource shock experiments.The speciating MacArthur modelEvolutionary dynamics modeling including MacArthur type models usually starts with describing population dynamics as ṅ(t) = n(t)f (n) with n the set of species population sizes and the dot denotes a time derivative. The crux is that f (n) is not constant but a growth rate determining function that depends on ecosystem features such as population sizes and coupling constants which specify inter-species competition and preying efficiency (Wangersky 1978; Cressman and Tao 2014). This general approach is tremendously successful ",
+            "file_name": "10!1007%s12080-023-00564-2.pdf",
+            "file_path": "output\\PDFs\\10!1007%s12080-023-00564-2.pdf"
+        },
+        {
+            "title": "Chance, long tails, and inference in a non-Gaussian, Bayesian theory of vocal learning in songbirds",
+            "implementation_urls": [
+                {
+                    "identifier": "https://github.com/EmoryUniversityTheoreticalBiophysics/NonGaussianLearning",
+                    "type": "git",
+                    "paper_frequency": 2,
+                    "extraction_methods": [
+                        {
+                            "type": "bidir",
+                            "location": "DESCRIPTION",
+                            "location_type": "TITLE",
+                            "source": "SOMEF",
+                            "source_paragraph": ""
+                        },
+                        {
+                            "type": "bidir",
+                            "location": "REPO_TITLE",
+                            "location_type": "TITLE",
+                            "source": "SOMEF",
+                            "source_paragraph": ""
+                        },
+                        {
+                            "type": "unidir",
+                            "location": "output\\PDFs\\10!1073%pnas!1713020115.pdf",
+                            "location_type": "PAPER",
+                            "source": "",
+                            "source_paragraph": "Data deposition: The code and data reported in this paper have been deposited on GitHub and are available at https://github.com/EmoryUniversityTheoreticalBiophysics/NonGaussianLearning."
+                        }
+                    ]
+                }
+            ],
+            "doi": "10.1073/pnas.1713020115",
+            "arxiv": "1707.07247",
+            "abstract": null,
+            "file_name": "10!1073%pnas!1713020115.pdf",
+            "file_path": "output\\PDFs\\10!1073%pnas!1713020115.pdf"
+        },
+        {
+            "title": "Precision and accuracy of single-molecule FRET measurements—a multi-laboratory benchmark study",
+            "implementation_urls": [],
+            "doi": "10.1038/s41592-018-0085-0",
+            "arxiv": "1710.03807",
+            "abstract": null,
+            "file_name": "10!1038%s41592-018-0085-0.pdf",
+            "file_path": "output\\PDFs\\10!1038%s41592-018-0085-0.pdf"
+        }
+    ]
+}

--- a/src/RSEF/extraction/paper_obj.py
+++ b/src/RSEF/extraction/paper_obj.py
@@ -1,22 +1,24 @@
 from ..object_creator.implementation_url import ImplementationUrl
 from ..utils.regex import str_to_doiID, str_to_arxivID
 
+
 class PaperObj:
     def __init__(self, title, implementation_urls, doi, arxiv, abstract, file_name, file_path):
-        self._title = title
-        self._implementation_urls = [ImplementationUrl.from_dict(url) for url in implementation_urls]
-        self._doi = str_to_doiID(doi)
-        self._arxiv = str_to_arxivID(arxiv)
-        self._file_name = file_name
-        self._file_path = file_path
-        self._abstract = abstract
+        self._title: str = title
+        self._implementation_urls: list[ImplementationUrl] = [
+            ImplementationUrl.from_dict(url) for url in implementation_urls]
+        self._doi: str = str_to_doiID(doi)
+        self._arxiv: str = str_to_arxivID(arxiv)
+        self._file_name: str = file_name
+        self._file_path: str = file_path
+        self._abstract: str = abstract
 
     def __str__(self):
         return f"Title: {self._title}\nImplementation URLs: {self._implementation_urls}\nDOI: {self._doi}\nArXiv: {self._arxiv}\nAbstract: {self._abstract}\nFile Name: {self._file_name}\nFile Path: {self._file_path}"
 
     def __repr__(self):
         return self.__str__()
-    
+
     @property
     def title(self):
         return self._title
@@ -31,7 +33,8 @@ class PaperObj:
 
     @implementation_urls.setter
     def implementation_urls(self, value):
-        self._implementation_urls = [ImplementationUrl.from_dict(url) for url in value]
+        self._implementation_urls = [
+            ImplementationUrl.from_dict(url) for url in value]
 
     def add_implementation_link(self, url, url_type, extraction_method, frequency=1):
         if self._implementation_urls is None:
@@ -40,7 +43,7 @@ class PaperObj:
         # Look for the url in the list of implementation urls
         for implementation_url in self._implementation_urls:
             if implementation_url.identifier == url:
-                implementation_url.extraction_methods.append(extraction_method.to_dict())
+                implementation_url.extraction_methods.append(extraction_method)
                 duplicate = True
                 break
         if not duplicate:
@@ -57,17 +60,16 @@ class PaperObj:
         try:
             for url in self._implementation_urls:
                 url.extraction_methods = [
-                    method for method in url.extraction_methods if method['type'] != 'regex'
+                    method for method in url.extraction_methods if method.type != 'regex'
                 ]
                 # Add the URL to filtered_urls if it has non-empty extraction methods
                 if url.extraction_methods:
                     filtered_urls.append(url)
-            
+
             # Update _implementation_urls to only include URLs with non-empty extraction methods
             self._implementation_urls = filtered_urls
         except Exception as e:
             print(f"An error occurred in remove_regex: {e}")
-    
 
     def remove_duplicated_extraction_methods(self):
         filtered_urls = []
@@ -78,33 +80,34 @@ class PaperObj:
                 has_citation_file = False
                 citation_file_location_type = None
                 cff_location_type = None
-                
+
                 for method in url.extraction_methods:
-                    if method['location'] == 'CITATION_FILE':
+                    if method.location == 'CITATION_FILE':
                         unique_methods.append(method)
                         has_citation_file = True
-                        citation_file_location_type = method['location_type']
-                    elif method['location'] == 'FILE_CFF':
-                        cff_location_type = method['location_type']
-                    elif method['location'] not in seen_locations:
-                        seen_locations.add(method['location'])
+                        citation_file_location_type = method.location_type
+                    elif method.location == 'FILE_CFF':
+                        cff_location_type = method.location_type
+                    elif method.location not in seen_locations:
+                        seen_locations.add(method.location)
                         unique_methods.append(method)
-                
+
                 for method in unique_methods:
-                    if method['location'] == 'FILE_CFF' and has_citation_file:
+                    if method.location == 'FILE_CFF' and has_citation_file:
                         unique_methods.remove(method)
-                    if method['location'] == 'CITATION_FILE' and citation_file_location_type != cff_location_type:
-                        method['location_type'] = f"{citation_file_location_type} , {cff_location_type}"
+                    if method.location == 'CITATION_FILE' and citation_file_location_type != cff_location_type:
+                        method.location_type(
+                            f"{citation_file_location_type} , {cff_location_type}")
                 url.extraction_methods = unique_methods
-                
+
                 if url.extraction_methods:
                     filtered_urls.append(url)
-            
-            self._implementation_urls = filtered_urls
-        
-        except Exception as e:
-            print(f"An error occurred in remove_duplicated_extraction_methods: {e}")
 
+            self._implementation_urls = filtered_urls
+
+        except Exception as e:
+            print(
+                f"An error occurred in remove_duplicated_extraction_methods: {e}")
 
     @property
     def abstract(self):

--- a/src/RSEF/object_creator/downloaded_to_paperObj.py
+++ b/src/RSEF/object_creator/downloaded_to_paperObj.py
@@ -27,7 +27,7 @@ def downloaded_to_paperObj(downloadedObj):
             for url_type, url_list in urls_dict.items():
                 for url in url_list:
                     extraction_method = ExtractionMethod(type="regex", location="", location_type="", source="", source_paragraph="")
-                    implementation_url = ImplementationUrl(identifier=url['url'], type=url_type, paper_frequency=url['#_appearances'], extraction_methods=[extraction_method.to_dict()]
+                    implementation_url = ImplementationUrl(identifier=url['url'], type=url_type, paper_frequency=url['#_appearances'], extraction_methods=[extraction_method]
                     )
                     urls.append(implementation_url.to_dict())
         abstract = get_possible_abstract(pdf_data_list)

--- a/src/RSEF/object_creator/extraction_method.py
+++ b/src/RSEF/object_creator/extraction_method.py
@@ -1,10 +1,10 @@
 class ExtractionMethod:
     def __init__(self, type, location="", location_type="", source="", source_paragraph=""):
-        self._type = type
-        self._location = location
-        self._location_type = location_type
-        self._source = source
-        self._source_paragraph = source_paragraph
+        self._type: str = type
+        self._location: str = location
+        self._location_type: str = location_type
+        self._source: str = source
+        self._source_paragraph: str = source_paragraph
 
     def __str__(self):
         return f"type: {self._type}\nlocation: {self._location}\nlocation_type: {self._location_type}\nsource: {self._source}\nsource_paragraph: {self._source_paragraph}\n"

--- a/src/RSEF/object_creator/implementation_url.py
+++ b/src/RSEF/object_creator/implementation_url.py
@@ -1,6 +1,3 @@
-from ..object_creator.extraction_method import ExtractionMethod
-
-
 class ImplementationUrl:
     def __init__(self, identifier, type, paper_frequency, extraction_methods):
         self._identifier = identifier

--- a/src/RSEF/object_creator/implementation_url.py
+++ b/src/RSEF/object_creator/implementation_url.py
@@ -1,9 +1,11 @@
+from .extraction_method import ExtractionMethod
+
 class ImplementationUrl:
     def __init__(self, identifier, type, paper_frequency, extraction_methods):
-        self._identifier = identifier
-        self._type = type
-        self._paper_frequency = paper_frequency
-        self._extraction_methods = extraction_methods if extraction_methods is not None else []
+        self._identifier: str = identifier
+        self._type: str = type
+        self._paper_frequency: int = paper_frequency
+        self._extraction_methods: list[ExtractionMethod] = extraction_methods if extraction_methods else []
 
     def __str__(self):
         return "URL: %s\nURL Type: %s\nFrequency: %s\nExtraction Methods: %s\n" % \
@@ -49,7 +51,7 @@ class ImplementationUrl:
             "identifier": self._identifier,
             "type": self._type,
             "paper_frequency": self._paper_frequency,
-            "extraction_methods": [em for em in self._extraction_methods] 
+            "extraction_methods": [em.to_dict() for em in self._extraction_methods] 
         }
 
     @staticmethod
@@ -58,5 +60,5 @@ class ImplementationUrl:
             identifier=dic["identifier"],
             type=dic["type"],
             paper_frequency=dic["paper_frequency"],
-            extraction_methods=dic["extraction_methods"]
+            extraction_methods= [ExtractionMethod.from_dict(em) for em in dic["extraction_methods"]]
         )

--- a/src/RSEF/object_creator/pipeline.py
+++ b/src/RSEF/object_creator/pipeline.py
@@ -49,9 +49,9 @@ def process_paper(paper, output_dir, bidir=True, unidir=True):
     """
     if paper.doi or paper.arxiv:
         if paper.doi:
-            log.info(f"Analyzing paper with DOI: {paper.doi}")    
+            log.info(f"Analyzing paper with DOI: {paper.doi}")
         if paper.arxiv:
-            log.info(f"Analyzing paper with DOI: {paper.arxiv}")    
+            log.info(f"Analyzing paper with DOI: {paper.arxiv}")
 
         if bidir:
             try:
@@ -64,18 +64,25 @@ def process_paper(paper, output_dir, bidir=True, unidir=True):
         if unidir:
             try:
                 log.info("Checking unidirectional links")
-                repo_link, source_para = extract_repo_links_from_pdf(paper.file_path)
+                repo_link, source_para = extract_repo_links_from_pdf(
+                    paper.file_path)
                 if repo_link:
-                    extraction_method = ExtractionMethod(type='unidir', location=paper.file_path , location_type='PAPER', source_paragraph=source_para)
-                    paper.add_implementation_link(repo_link, 'git', extraction_method=extraction_method)
+                    extraction_method = ExtractionMethod(
+                        type='unidir', location=paper.file_path, location_type='PAPER', source_paragraph=source_para)
+                    paper.add_implementation_link(
+                        repo_link, 'git', extraction_method=extraction_method.to_dict())
             except Exception as e:
-                log.error("Error extracting unidirectional relationship" + str(e))
+                log.error(
+                    "Error extracting unidirectional relationship" + str(e))
                 return paper
-                
+
         log.info(f"Finished analyzing paper with DOI: {paper.doi}")
+        
+    # Clean up the paper object
+    paper.remove_duplicated_extraction_methods()
+    paper.remove_regex()
     
     return paper
-    
 
 
 def single_doi_pipeline(doi, output_dir, bidir=True, unidir=True):
@@ -142,23 +149,27 @@ def multi_doi_pipeline(list_dois, output_dir, bidir=True, unidir=True):
     """
     result = []
 
-    try:
-        for doi in list_dois:
+    for doi in list_dois:
+        try:
             paper = doi_to_paper(doi, output_dir)
 
             if not paper:
                 log.error("Error while creating paperObj")
-                return None
+                continue
+
+            if not paper.implementation_urls:
+                log.info("No implementation URLs found")
+                continue
 
             paper = process_paper(
                 paper, output_dir, bidir=bidir, unidir=unidir)
 
             result.append(paper.to_dict())
+        except Exception as e:
+            log.error(f"Error while processing {doi}")
+            log.error(str(e))
 
-        return dict_to_json({'RSEF Output': result}, output_path=os.path.join(output_dir, "url_search_output.json"))
-    except Exception as e:
-        log.error(str(e))
-        return None
+    return dict_to_json({'RSEF Output': result}, output_path=os.path.join(output_dir, "url_search_output.json"))
 
 
 def multi_doi_search(dois_txt, output_dir, bidir=True, unidir=True):
@@ -191,10 +202,11 @@ def dict_to_json(dictionary, output_path):
         if not os.path.exists(directory):
             os.makedirs(directory)
 
-        with open(output_path, 'w+') as out_file:
+        with open(output_path, 'w+', encoding='utf-8') as out_file:
             json.dump(dictionary, out_file, indent=4, ensure_ascii=False)
         return output_path
     except Exception as e:
+        log.error("Error while trying to save the JSON")
         log.error(str(e))
         return None
 
@@ -224,7 +236,7 @@ def paper_objects_search(papers_json, output_dir, bidir=True, unidir=True):
         log.error(str(e))
         return
 
-    for index, obj in enumerate(paper_dicts):
+    for obj in paper_dicts:
         if obj['doi']:
             log.info(f"Analyzing directionality for {obj['doi']}")
         elif obj['arxiv']:
@@ -236,23 +248,22 @@ def paper_objects_search(papers_json, output_dir, bidir=True, unidir=True):
             return None
 
         paper = process_paper(paper, output_dir, bidir=bidir, unidir=unidir)
-
-        paper.remove_duplicated_extraction_methods()
-        paper.remove_regex()
-
+        
         try:
             paper_dict = paper.to_dict()
             save_dict_to_json(paper_dict, file_path)
         except Exception as e:
-            log.error(f"Error while converting paperObj to dict for {obj['doi']}: {e}")
+            log.error(
+                f"Error while converting paperObj to dict for {obj['doi']}: {e}")
             continue
 
     try:
         remove_empty_fields_from_file(file_path)
     except Exception as e:
         log.error(f"Error while deleting the empty values from JSON: {e}")
-        
+
     return file_path
+
 
 def safe_dic(dic, key):
     try:

--- a/src/RSEF/object_creator/pipeline.py
+++ b/src/RSEF/object_creator/pipeline.py
@@ -5,6 +5,7 @@ from .downloaded_to_paperObj import downloaded_to_paperObj
 from .paper_to_directionality import check_bidir, check_unidir
 from .paper_obj_utils import paperDict_to_paperObj
 from ..repofrompaper.rfp import extract_repo_links_from_pdf
+from ..extraction.paper_obj import PaperObj
 import logging
 import json
 import os
@@ -38,7 +39,7 @@ def pdf_to_paper(pdf, output_dir):
     return downloaded_to_paperObj(downloadedObj=dwnldd)
 
 
-def process_paper(paper, output_dir, bidir=True, unidir=True):
+def process_paper(paper: PaperObj, output_dir, bidir=True, unidir=True):
     """
     :param paper: paperObj
     :param output_dir: output directory
@@ -51,7 +52,7 @@ def process_paper(paper, output_dir, bidir=True, unidir=True):
         if paper.doi:
             log.info(f"Analyzing paper with DOI: {paper.doi}")
         if paper.arxiv:
-            log.info(f"Analyzing paper with DOI: {paper.arxiv}")
+            log.info(f"Analyzing paper with Arxiv ID: {paper.arxiv}")
 
         if bidir:
             try:
@@ -70,10 +71,10 @@ def process_paper(paper, output_dir, bidir=True, unidir=True):
                     extraction_method = ExtractionMethod(
                         type='unidir', location=paper.file_path, location_type='PAPER', source_paragraph=source_para)
                     paper.add_implementation_link(
-                        repo_link, 'git', extraction_method=extraction_method.to_dict())
+                        repo_link, 'git', extraction_method=extraction_method)
             except Exception as e:
                 log.error(
-                    "Error extracting unidirectional relationship" + str(e))
+                    "Error extracting unidirectional relationship: " + str(e))
                 return paper
 
         log.info(f"Finished analyzing paper with DOI: {paper.doi}")


### PR DESCRIPTION
This PR fixes the issues reported in #37.

- The try block and for blocks are now correctly order, and the failed processing of one paper will not end the execution of the whole process.
- ExtractionMethod objects are kept as dict to ensure serializability.
- JSON output is set with encoding 'utf-8'
- Paper cleaning is now added at the end of `process_paper` to ensure clean papers before sending them for writing out.

Furthermore, this PR closes #35 by adding a sample output file.