### PR TITLE
Add Publication Date and Author to Metadata

### DIFF
--- a/src/RSEF/__main__.py
+++ b/src/RSEF/__main__.py
@@ -81,7 +81,6 @@ def cli():
 @click.option('--unidir', '-U', is_flag=True, default=False, help="Unidirectionality")
 @click.option('--bidir', '-B', is_flag=True, default=False, help="Bidirectionality")
 def assess(input, output, unidir, bidir):
-
     # Clear the content of the url_search_output.json
     url_search_output_path = output + ASSES_PATH
     if os.path.exists(url_search_output_path):        

--- a/src/RSEF/download_pdf/downloaded_obj.py
+++ b/src/RSEF/download_pdf/downloaded_obj.py
@@ -7,15 +7,19 @@ from ..utils.regex import (
 
 class DownloadedObj:
 
-    def __init__(self, title, doi, arxiv, file_name, file_path):
+    def __init__(self, title, doi, arxiv, publication_date, authors, file_name, file_path):
         self._title = title
         self._doi = str_to_doiID(doi)
         self._arxiv = str_to_arxivID(arxiv)
+        self._publication_date = publication_date
+        self._authors = authors
         self._file_name = file_name
         self._file_path = file_path
 
     def __str__(self):
-        return f"Title: {self._title}\nDOI: {self._doi}\nArXiv: {self._arxiv}\nFile Name: {self._file_name}\nFile Path: {self._file_path}"
+        return f"Title: {self._title}\nDOI: {self._doi}\nArXiv: {self._arxiv}\n\
+                    Publication Date: {self._publication_date}\nAuthors: {self._authors}\n\
+                        File Name: {self._file_name}\nFile Path: {self._file_path}"
 
     @property
     def title(self):
@@ -56,12 +60,30 @@ class DownloadedObj:
     @file_path.setter
     def file_path(self, value):
         self._file_path = value
+        
+    @property
+    def publication_date(self):
+        return self._publication_date
+    
+    @publication_date.setter
+    def publication_date(self, value):
+        self._publication_date = value
+        
+    @property
+    def authors(self):
+        return self._authors
+    
+    @authors.setter
+    def authors(self, value):
+        self._authors = value
 
     def to_dict(self):
         return {
             'title': self._title,
             'doi': self._doi,
             'arxiv': self.arxiv,
+            'publication_date': self._publication_date,
+            'authors': ", ".join(self._authors) if self._authors else "",
             'file_name': self._file_name,
             'file_path': self._file_path
         }

--- a/src/RSEF/extraction/paper_obj.py
+++ b/src/RSEF/extraction/paper_obj.py
@@ -3,18 +3,22 @@ from ..utils.regex import str_to_doiID, str_to_arxivID
 
 
 class PaperObj:
-    def __init__(self, title, implementation_urls, doi, arxiv, abstract, file_name, file_path):
+    def __init__(self, title, implementation_urls, doi, arxiv, abstract, publication_date, authors, file_name, file_path):
         self._title: str = title
         self._implementation_urls: list[ImplementationUrl] = [
             ImplementationUrl.from_dict(url) for url in implementation_urls]
         self._doi: str = str_to_doiID(doi)
         self._arxiv: str = str_to_arxivID(arxiv)
+        self._abstract: str = abstract
+        self.publication_date = publication_date
+        self.authors = authors
         self._file_name: str = file_name
         self._file_path: str = file_path
-        self._abstract: str = abstract
 
     def __str__(self):
-        return f"Title: {self._title}\nImplementation URLs: {self._implementation_urls}\nDOI: {self._doi}\nArXiv: {self._arxiv}\nAbstract: {self._abstract}\nFile Name: {self._file_name}\nFile Path: {self._file_path}"
+        return f"Title: {self._title}\nImplementation URLs: {self._implementation_urls}\nDOI: {self._doi}\n\
+                ArXiv: {self._arxiv}\nAbstract: {self._abstract}\nPublication Date: {self.publication_date}\n\
+                Authors: {self.authors}\nFile Name: {self._file_name}\nFile Path: {self._file_path}"
 
     def __repr__(self):
         return self.__str__()
@@ -148,6 +152,22 @@ class PaperObj:
     @file_path.setter
     def file_path(self, value):
         self._file_path = value
+        
+    @property
+    def publication_date(self):
+        return self._publication_date
+    
+    @publication_date.setter
+    def publication_date(self, value):
+        self._publication_date = value
+        
+    @property
+    def authors(self):
+        return self._authors
+    
+    @authors.setter
+    def authors(self, value):
+        self._authors = value
 
     def to_dict(self):
         return {
@@ -156,6 +176,8 @@ class PaperObj:
             'doi': self._doi,
             'arxiv': self._arxiv,
             'abstract': self._abstract,
+            'publication_date': self.publication_date,
+            'authors': ", ".join(self.authors) if self.authors else "",
             'file_name': self._file_name,
             'file_path': self._file_path
         }

--- a/src/RSEF/metadata/metadata_obj.py
+++ b/src/RSEF/metadata/metadata_obj.py
@@ -4,10 +4,12 @@ from ..utils.regex import (
 )
 
 class MetadataObj:
-    def __init__(self, title, doi, arxiv):
+    def __init__(self, title, doi, arxiv, publication_date=None, authors: list=None):
         self._title = title
         self._doi = str_to_doiID(doi)
         self._arxiv = str_to_arxivID(arxiv)
+        self.authors = authors
+        self.publication_date = publication_date
 
     @property
     def title(self):
@@ -32,13 +34,32 @@ class MetadataObj:
     @arxiv.setter
     def arxiv(self, value):
         self._arxiv = value
+        
+    @property
+    def publication_date(self):
+        return self._publication_date
+    
+    @publication_date.setter
+    def publication_date(self, value):
+        self._publication_date = value
+        
+    @property
+    def authors(self):
+        return self._authors
+    
+    @authors.setter
+    def authors(self, value):
+        self._authors = value
 
     def to_dict(self):
         return {
             'title': self._title,
             'doi': self._doi,
             'arxiv': self.arxiv,
+            'publication_date': self.publication_date,
+            'authors': self.authors
         }
         
     def __str__(self):
-        return f"Title: {self._title}, DOI: {self._doi}, Arxiv: {self._arxiv}"
+        authors_str = ", ".join(self.authors) if self.authors else ""
+        return f"Title: {self._title}, DOI: {self._doi}, Arxiv: {self._arxiv}, Authors: {authors_str}, Publication Date: {self.publication_date}"

--- a/src/RSEF/object_creator/create_downloadedObj.py
+++ b/src/RSEF/object_creator/create_downloadedObj.py
@@ -29,7 +29,15 @@ def meta_to_dwnldd(metadataObj, output_dir):
         if not file_path:
             return None
         file_name = os.path.basename(file_path)
-        return DownloadedObj(title=metadataObj.title,doi=metadataObj.doi,arxiv=metadataObj.arxiv,file_name=file_name,file_path=file_path)
+        return DownloadedObj(
+                title=metadataObj.title,
+                doi=metadataObj.doi,
+                arxiv=metadataObj.arxiv,
+                publication_date=metadataObj.publication_date,
+                authors=metadataObj.authors,
+                file_name=file_name,
+                file_path=file_path
+            )
     except Exception as e:
         try:
             meta_doi = str(metadataObj.doi)
@@ -63,9 +71,11 @@ def downloadedDic_to_downloadedObj(dwnldd_dict):
     title = safe_dic(dwnldd_dict, "title")
     doi = safe_dic(dwnldd_dict, "doi")
     arxiv = safe_dic(dwnldd_dict, "arxiv")
+    publication_date = safe_dic(dwnldd_dict, "publication_date")
+    authors = safe_dic(dwnldd_dict, "authors")
     file_name = safe_dic(dwnldd_dict, "file_name")
     file_path = safe_dic(dwnldd_dict, "file_path")
-    return DownloadedObj(title=title, doi=doi, arxiv=arxiv, file_name=file_name, file_path=file_path)
+    return DownloadedObj(title=title, doi=doi, arxiv=arxiv, publication_date=publication_date, authors=authors, file_name=file_name, file_path=file_path)
 
 
 def metaDict_to_downloaded(meta_dict, output_dir):
@@ -131,9 +141,11 @@ def _doi_to_downloaded_obj_backup(id,output_dir):
         match = re.match(DOI_REGEX, id, re.IGNORECASE)
         if match: # id is a doi
             return DownloadedObj(title=extract_pdf_title(pdf_path=file_path), doi=id, arxiv=None,
+                                 publication_date=None, authors=None,
                                 file_name=os.path.basename(file_path), file_path=file_path)
         else: # id is an arxiv
             return DownloadedObj(title=extract_pdf_title(pdf_path=file_path), doi=None, arxiv=id,
+                                 publication_date=None, authors=None,
                                 file_name=os.path.basename(file_path), file_path=file_path)
     except Exception as e:
         logging.error(f"An error occurred in _doi_to_downloaded_obj_backup: {str(e)}")
@@ -196,7 +208,9 @@ def pdf_to_downloaded_obj(pdf,output_dir):
     titL = safe_dic(resp_jsn, "title")
     doi = str_to_doiID(safe_dic(resp_jsn, "doi"))
     arxiv = extract_arxivID(resp_jsn)
-    return DownloadedObj(title=titL,doi=doi,arxiv=arxiv,file_name="",file_path=pdf)
+    publication_date = safe_dic(resp_jsn, "publication_date")
+    authors = safe_dic(resp_jsn, "authors")
+    return DownloadedObj(title=titL,doi=doi,arxiv=arxiv,publication_date=publication_date, authors=authors,file_name="",file_path=pdf)
 
 # Download papers from a json containing title, doi, primary location (PDF's URL)
 def json_to_downloaded_obj(json_data, output_dir):

--- a/src/RSEF/object_creator/create_metadata_obj.py
+++ b/src/RSEF/object_creator/create_metadata_obj.py
@@ -38,13 +38,20 @@ def doi_to_metadataObj(doi):
         except Exception as e:
             log.error(str(e))
             return None
+        
         if oa_meta is None:
             log.debug("No meta")
+            
         titL = safe_dic(oa_meta, "title")
         doi = str_to_doiID(safe_dic(oa_meta, "doi"))
         arxiv = extract_arxivID(oa_meta)
-        metadata = MetadataObj(title=titL, doi=doi, arxiv=arxiv)
-        return metadata
+        publication_date = safe_dic(oa_meta, "publication_date")
+        
+        authorships, authors = safe_dic(oa_meta, "authorships"), []
+        for author in authorships:
+            authors.append(safe_dic(safe_dic(author, "author"), "display_name"))
+            
+        return MetadataObj(title=titL, doi=doi, arxiv=arxiv, publication_date=publication_date, authors=authors)
     except Exception as e:
         log.error(str(e))
 
@@ -134,7 +141,9 @@ def metaDict_to_metaObj(meta_dict):
     title = safe_dic(meta_dict, "title")
     doi = safe_dic(meta_dict, "doi")
     arxiv = safe_dic(meta_dict, "arxiv")
-    return MetadataObj(title=title, doi=doi, arxiv=arxiv)
+    publication_date = safe_dic(meta_dict, "publication_date")
+    authors = safe_dic(meta_dict, "authors")
+    return MetadataObj(title=title, doi=doi, arxiv=arxiv, publication_date=publication_date, authors=authors)
 
 
 def safe_dic(dic, key):

--- a/src/RSEF/object_creator/downloaded_to_paperObj.py
+++ b/src/RSEF/object_creator/downloaded_to_paperObj.py
@@ -34,9 +34,21 @@ def downloaded_to_paperObj(downloadedObj):
         title = downloadedObj.title
         doi = downloadedObj.doi
         arxiv = downloadedObj.arxiv
+        publication_date = downloadedObj.publication_date
+        authors = downloadedObj.authors
         file_name = downloadedObj.file_name
         file_path = downloadedObj.file_path
-        return PaperObj(title=title, implementation_urls=urls, doi=doi, arxiv=arxiv, abstract=abstract, file_name=file_name, file_path=file_path)
+        return PaperObj(
+            title=title, 
+            implementation_urls=urls, 
+            doi=doi, 
+            arxiv=arxiv, 
+            abstract=abstract, 
+            publication_date=publication_date, 
+            authors=authors, 
+            file_name=file_name, 
+            file_path=file_path
+        )
     except Exception as e:
         print(str(e))
         print("Error while trying to read from the pdf")

--- a/src/RSEF/object_creator/paper_obj_utils.py
+++ b/src/RSEF/object_creator/paper_obj_utils.py
@@ -6,12 +6,24 @@ def paperDict_to_paperObj(paper_dict):
     title = safe_dic(paper_dict, "title")
     doi = safe_dic(paper_dict, "doi")
     arxiv = safe_dic(paper_dict, "arxiv")
+    publication_date = safe_dic(paper_dict, "publication_date")
+    authors = safe_dic(paper_dict, "authors")
     file_name = safe_dic(paper_dict,"file_name")
     file_path = safe_dic(paper_dict,"file_path")
     urls = safe_dic(paper_dict,"implementation_urls")
     abstract = safe_dic(paper_dict,"abstract")
-    return PaperObj(title=title, implementation_urls=urls, doi=doi, arxiv=arxiv, file_name=file_name, file_path=file_path, abstract=abstract)
-
+    
+    return PaperObj(
+            title=title, 
+            implementation_urls=urls, 
+            doi=doi, 
+            arxiv=arxiv, 
+            abstract=abstract, 
+            publication_date=publication_date, 
+            authors=authors, 
+            file_name=file_name, 
+            file_path=file_path
+    )
 
 def safe_dic(dic, key):
     try:

--- a/src/RSEF/object_creator/pdf_to_downloaded.py
+++ b/src/RSEF/object_creator/pdf_to_downloaded.py
@@ -34,7 +34,13 @@ def pdfDoi_to_downloaded(doi,file_path):
         doi = str_to_doiID(safe_dic(oa_meta, "doi"))
         arxiv = extract_arxivID(oa_meta)
         file_name = os.path.basename(file_path)
-        return DownloadedObj(titL,doi,arxiv,file_name,file_path)
+        publication_date = safe_dic(oa_meta, "publication_date")
+        
+        authorships, authors = safe_dic(oa_meta, "authorships"), []
+        for author in authorships:
+            authors.append(safe_dic(safe_dic(author, "author"), "display_name"))
+            
+        return DownloadedObj(titL, doi, arxiv, publication_date, authors, file_name, file_path)
     except Exception as e:
         print(str(e))
 


### PR DESCRIPTION
This PR simply adds two new fields to the Metadata, Downloaded and Paper objects. These fields are useful improve the possible presentation of the RSEF results. The current format of the RSEF output is the following:

`
{
    "RSEF Output": [
        {
            "title": "Empowering Museum Experiences Applying Gamification Techniques Based on Linked Data and Smart Objects",
            "implementation_urls": [],
            "doi": "10.3390/app10165419",
            "arxiv": null,
            "abstract": "Abstract: Museums play a crucial role in preserving cultural heritage.",
            "publication_date": "2020-08-05",
            "authors": [
                "Alejandro López-Martínez",
                "Álvaro Carrera",
                "Carlos Á. Iglesias"
            ],
            "file_name": "10!3390%app10165419.pdf",
            "file_path": "output\\PDFs\\10!3390%app10165419.pdf"
        }
    ]
}
`