### PR TITLE
Save logs to a file

### DIFF
--- a/src/RSEF/__main__.py
+++ b/src/RSEF/__main__.py
@@ -8,14 +8,20 @@ from .object_creator.create_downloadedObj import pdf_to_downloaded_obj, json_to_
 from .object_creator.downloaded_to_paperObj import dwnldd_obj_to_paper_dic
 from .output_analysis.analysis import output_analysis
 from . import __version__
+import datetime
+import logging
 import click
 import os
-import logging
+
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 VALID_EXTENSIONS = ['.txt', '.json']
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    filename=f"output/logs/rsef_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.log", 
+    level=logging.INFO, 
+    format='%(asctime)s:%(levelname)s:%(message)s'
+)
 log = logging.getLogger(__name__)
 
 

--- a/src/RSEF/download_pdf/arxiv_downloader.py
+++ b/src/RSEF/download_pdf/arxiv_downloader.py
@@ -4,6 +4,8 @@ import requests
 import logging
 from ..utils.regex import str_to_arxivID
 
+log = logging.getLogger(__name__)
+
 # Deprecated but keep around to view old usage
 # def filter_arxiv(file_path):
 #     # Read the csv file
@@ -35,14 +37,14 @@ def download_pdf(url, output_dir):
     try:
         r = requests.get(url)
         if r.status_code != 200:
-            logging.debug("Failed to download PDF from URL: %s (Status Code: %s)", url, r.status_code)
+            log.debug("Failed to download PDF from URL: %s (Status Code: %s)", url, r.status_code)
             return None
         output_path = os.path.join(output_dir, url.split('/')[-1])
         with open(output_path, 'wb') as f:
             f.write(r.content)
         return output_path
     except Exception as e:
-        logging.error("Issue when trying to download Arxiv PDF %s", str(e))
+        log.error("Issue when trying to download Arxiv PDF %s", str(e))
         return None
 
 

--- a/src/RSEF/download_pdf/download_pipeline.py
+++ b/src/RSEF/download_pdf/download_pipeline.py
@@ -5,6 +5,7 @@ from .unpaywall_pdf_url_extractor import create_unpaywall_url_from_string as pay
 from .arxiv_downloader import download_pdf as download_arxiv_pdf
 from .unpaywall_pdf_downloader import doi_to_downloaded_pdf
 
+log = logging.getLogger(__name__)
 
 def pdf_download_pipeline(id, output_directory):
     """
@@ -26,19 +27,19 @@ def pdf_download_pipeline(id, output_directory):
             # Creates Directory if it does not exist
             os.mkdir(pdf_output_directory)
     except Exception as e:
-        logging.error(f"Error while trying to create the directory  Err @ PDF download {str(e)}")
+        log.error(f"Error while trying to create the directory Err @ PDF download {str(e)}")
 
-    logging.debug(f"Attempting to download pdf for {str(id)}")
+    log.debug(f"Attempting to download pdf for {str(id)}")
     if (file_path := download_arxiv_pdf(id, pdf_output_directory)):
         return file_path
     else:
         url = paywall_url(id)
         if not url:
-            logging.debug("We are only able to download pdfs via arxiv or doi for now, sorry")
+            log.debug("We are only able to download pdfs via arxiv or doi for now, sorry")
             return None
         file_path = doi_to_downloaded_pdf(url, id, pdf_output_directory)
     if file_path:
-        logging.info("Success downloading the pdf file")
+        log.info("Success downloading the pdf file")
         return file_path
     else:
         return None

--- a/src/RSEF/download_pdf/unpaywall_pdf_downloader.py
+++ b/src/RSEF/download_pdf/unpaywall_pdf_downloader.py
@@ -6,6 +6,7 @@ import os
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urljoin
 
+log = logging.getLogger(__name__)
 
 def doi_to_downloaded_pdf(url, doi, output_dir):
     '''
@@ -33,17 +34,17 @@ def doi_to_downloaded_pdf(url, doi, output_dir):
         pdf = try_other_locations(upaywll)
     # Check if no pdf has been found
     if not pdf:
-        logging.error(f"Failed to download the pdf for {str(doi)} with {str(url)}")
+        log.debug(f"Failed to download the PDF for {str(doi)} with {str(url)}")
         return None
     # if success
     try:
         pdf_filepath = os.path.join(output_dir, file_name)
         with open(pdf_filepath, 'wb') as f:  # here download the pdf
             f.write(pdf)
-            logging.debug('written pdf successfully')
+            log.info('PDF written successfully from Unpaywall')
         return pdf_filepath
     except Exception as e:
-        logging.error(f"Exception! Failed to download the pdf for {str(doi)} with {str(url)}, {str(e)}")
+        log.error(f"Exception! Failed to save the PDF for {str(doi)} with {str(url)}, {str(e)}")
         return None
 
 
@@ -65,7 +66,7 @@ def try_other_locations(jayson: json):
         return None
     except Exception as e:
         error_msg = f"Backup Error: An error occurred - {str(e)}"
-        logging.error(error_msg)
+        log.error(error_msg)
         return None
 
 
@@ -190,8 +191,7 @@ def _unpaywall_response_to_json(url: str):
         json_idk = json.loads(idk)
         return json_idk
     except Exception as e:
-        logging.error(f"Issue while trying to get the unpaywall response {str(e)}")
-        logging.error(f"Failed to download the pdf\n")
+        log.error(f"Failed to download the PDF: Issue while trying to get the unpaywall response {str(e)}")
         return None
 
 
@@ -214,7 +214,7 @@ def detect_content_type(response):
         print(f"An error occurred: {e}")
         return "Error"
     except Exception as e:
-        logging.error(f"Unknown Issue when determining the content type {str(e)}")
+        log.error(f"Unknown Issue when determining the content type {str(e)}")
         return "Error"
 
 
@@ -222,5 +222,5 @@ def safe_dic(dic, key):
     try:
         return dic[key]
     except Exception as e:
-        logging.error(f"Issue when opening the Dictionary {str(e)}")
+        log.error(f"Issue when opening the Dictionary {str(e)}")
         return None

--- a/src/RSEF/extraction/pdf_extraction_tika.py
+++ b/src/RSEF/extraction/pdf_extraction_tika.py
@@ -6,7 +6,7 @@ from tika import parser
 # Import REGEXes
 from ..utils.regex import ZENODO_DOI_REGEX, ZENODO_RECORD_REGEX, GITHUB_REGEX, GITLAB_REGEX
 
-logger = logging.getLogger("extraction")
+log = logging.getLogger(__name__)
 
 
 # ======================================================================================================================
@@ -22,20 +22,20 @@ def raw_read_pdf(pdf_path) -> str:
         parsed = parser.from_file(path)
         content = parsed.get('content', None)
         if not content:
-            logging.debug("Issue when retrieving pdf content TIKA")
+            log.debug("Issue when retrieving pdf content TIKA")
         return content
     except FileNotFoundError:
-        logging.error(f"PDF file not found at path: {pdf_path}")
+        log.error(f"PDF file not found at path: {pdf_path}")
         return ""
     except Exception as e:
-        logging.error(f"An error occurred while reading the PDF: {str(e)}")
+        log.error(f"An error occurred while reading the PDF: {str(e)}")
         return ""
 
 
 def raw_to_list(raw_pdf_data: str) -> list:
 
     if not raw_pdf_data:
-        logging.debug(f"converting from raw pdf to list pdf, {raw_pdf_data}")
+        log.debug(f"converting from raw pdf to list pdf, {raw_pdf_data}")
         return []
 
     list_pdf_data = raw_pdf_data.split('\n')
@@ -52,10 +52,10 @@ def read_pdf_list(pdf_path, splitter='\n') -> list:
         return list_pdf_data
 
     except FileNotFoundError:
-        logging.error(f"PDF file not found at path: {pdf_path}")
+        log.error(f"PDF file not found at path: {pdf_path}")
         return []
     except Exception as e:
-        logging.error(f"An error occurred while reading the PDF: {str(e)}")
+        log.error(f"An error occurred while reading the PDF: {str(e)}")
         return []
 # ======================================================================================================================
 # TITLE EXTRACTION
@@ -112,7 +112,7 @@ def find_abstract_index(pdf_data: list) -> int:
                     return index
             index += 1
     except Exception as e:
-        logging.warning(f"Failed to Extract the abstract {str(e)}")
+        log.warning(f"Failed to Extract the abstract {str(e)}")
         return -1
     return index
 
@@ -123,7 +123,7 @@ def get_possible_abstract(pdf_data: list) -> str:
         if index > 0:
             return ''.join(pdf_data[index:index+50])
     except Exception as e:
-        logging.error(f"get_possible_abstract: Issue while trying to extract the abstract: {e}")
+        log.error(f"get_possible_abstract: Issue while trying to extract the abstract: {e}")
 
 
 def find_github_in_abstract(pdf_data: list) -> list:
@@ -246,10 +246,10 @@ def extract_urls(raw_pdf_data: str, list_pdf_data: list) -> dict:
     #list_pdf_data = raw_to_list(raw_pdf_data)
     urls = {}
     if not raw_pdf_data:
-        logging.debug("Extract Urls: raw_pdf_data is None or Empty")
+        log.debug("Extract Urls: raw_pdf_data is None or Empty")
         return urls
     if not list_pdf_data:
-        logging.debug("Extract Urls: list_pdf_data is None or Empty")
+        log.debug("Extract Urls: list_pdf_data is None or Empty")
         return urls
 
     list_git_urls = ranked_git_url(list_pdf_data)

--- a/src/RSEF/extraction/pdf_title_extraction.py
+++ b/src/RSEF/extraction/pdf_title_extraction.py
@@ -3,7 +3,7 @@ import subprocess
 import logging
 from ..extraction.pdf_extraction_tika import get_possible_title as use_tika_title
 
-
+log = logging.getLogger(__name__)
 
 def extract_pdf_title(pdf_path):
 
@@ -11,7 +11,7 @@ def extract_pdf_title(pdf_path):
         print("This is the extracted title " + title)
         return title
     else:
-        logging.warning("pdf_title was not able to extract the title will fallback to Tika")
+        log.warning("pdf_title was not able to extract the title will fallback to Tika")
         title = use_tika_title(pdf_path)
     print("This is the extracted title " + title)
     return title
@@ -26,7 +26,7 @@ def use_pdf_title(pdf):
     """
     pdf = os.path.abspath(pdf)
     if not os.path.exists(pdf):
-        logging.debug(f"PDF file not found at path: {pdf}")
+        log.info(f"PDF file not found at path: {pdf}")
         return None
     # Runs the pdftitle module as a subprocess and communicate with it
     try:
@@ -36,11 +36,11 @@ def use_pdf_title(pdf):
         # Extracts and returns the pdf title from stdout
         pdf_title = stdout.strip()
         if pdf_title == "":
-            logging.debug("Issue extracting Pdf title")
+            log.debug("Issue extracting Pdf title")
             return None
         return pdf_title
     except Exception as e:
-        logging.error(str(e), exc_info=True)
+        log.error(str(e), exc_info=True)
         pass
         return None
 

--- a/src/RSEF/extraction/somef_extraction/somef_extractor.py
+++ b/src/RSEF/extraction/somef_extraction/somef_extractor.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -6,6 +5,7 @@ import subprocess
 
 from ...utils.regex import str_to_doi_list, str_to_arxiv_list, str_to_arxivID
 
+log = logging.getLogger(__name__)
 
 # DOWNLOAD
 def is_github_repo_url(url):
@@ -62,10 +62,10 @@ def download_repo_metadata(url, output_folder_path):
     None if failure/invalid input
     """
     if not is_valid_repo_url(url):
-        logging.debug("download_repo_metadata: URL given is not a valid github/gitlab url")
+        log.info("download_repo_metadata: URL given is not a valid github/gitlab url")
         return None
     if not output_folder_path:
-        logging.debug("download_repo_metadata: No output path")
+        log.info("download_repo_metadata: No output path")
         return None
     pattern = r'(?:http|https)://(?:gitlab\.com|github\.com)/'
     replacement = ''
@@ -80,7 +80,7 @@ def download_repo_metadata(url, output_folder_path):
 
     output_file_path = os.path.join(output_folder_path, file)
     if os.path.exists(output_file_path):
-        logging.debug('Already created a file: ' + output_file_path)
+        log.info('Already created a file: ' + output_file_path)
         return output_file_path
     else:
         try:
@@ -91,10 +91,10 @@ def download_repo_metadata(url, output_folder_path):
                 raise Exception(
                     f"SOMEF Command failed with return code {completed_process.returncode}: {completed_process.stderr}")
         except subprocess.TimeoutExpired:
-            logging.error(f"ERROR: {url} SOMEF command timed out after 5 minutes")
+            log.error(f"ERROR: {url} SOMEF command timed out after 5 minutes")
             return None
         except Exception as e:
-            logging.error(f"ERROR:{url} SOMEF failed due to: {str(e)}")
+            log.error(f"ERROR:{url} SOMEF failed due to: {str(e)}")
             return None
     return output_file_path
 
@@ -179,7 +179,7 @@ def find_doi_citation(somef_data: dict):
                     citation_dois["BIBTEX"].append((doi, source))
             else:
                 print("doi_citation: Unexpected Format, maybe a somef update?")
-                logging.warning(f"Unexpected, format, has there been a somef update? {format}")
+                log.warning(f"Unexpected, format, has there been a somef update? {format}")
                 continue
         else:
             if safe_dic(result, "type") == 'Text_excerpt':
@@ -224,7 +224,7 @@ def find_arxiv_citation(somef_data: dict):
                     citation_arxivs["BIBTEX"].append((arxiv, source))
             else:
                 print("arxiv_citation: Unexpected Format, maybe a somef update?")
-                logging.warning(f"Unexpected, format, has there been a somef update? {format}")
+                log.warning(f"Unexpected, format, has there been a somef update? {format}")
                 continue
         else:
             if safe_dic(result, "type") == 'Text_excerpt':

--- a/src/RSEF/metadata/api/openAlex_api_queries.py
+++ b/src/RSEF/metadata/api/openAlex_api_queries.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import requests
 import json
@@ -9,6 +8,7 @@ from ...utils.regex import str_to_doiID, str_to_arxivID
 
 BASE_URL = 'https://api.openalex.org/works'
 
+log = logging.getLogger(__name__)
 
 def create_arxiv_doi(arxiv):
     # Every arxiv after 2022 has an automatically generated doi like the one below
@@ -30,14 +30,14 @@ def query_openalex_api(doi):
     try:
         response = requests.get(url)
         if response.status_code != 200:
-            logging.debug("HTTP request failed with status code: %s", response.status_code)
+            log.debug("HTTP request failed with status code: %s", response.status_code)
             return None
         data = response.json()
         return data
     except json.JSONDecodeError as e:
-        logging.error("Error decoding JSON response: %s", str(e))
+        log.error("Error decoding JSON response: %s", str(e))
     except Exception as e:
-        logging.error("Other Error has been produced %s", str(e))
+        log.error("Other Error has been produced %s", str(e))
     return None
 
 

--- a/src/RSEF/modelling/git_bidirectionality.py
+++ b/src/RSEF/modelling/git_bidirectionality.py
@@ -7,13 +7,14 @@ from ..extraction.somef_extraction.somef_extractor import (
     get_related_paper
 )
 
+log = logging.getLogger(__name__)
 
 def load_json(path):
     try:
         with open(path, 'r') as f:
             return json.load(f)
     except:
-        logging.error("Error while trying to open the repository JSON")
+        log.error("Error while trying to open the repository JSON")
         return None
 
 
@@ -28,7 +29,7 @@ def is_it_bidir(paper_obj, repo_json):
 
     """
     if not (repo_data := load_json(repo_json)):
-        logging.debug("is_it_bidir: Error while trying to open repository JSON")
+        log.debug("is_it_bidir: Error while trying to open repository JSON")
         return None
     bidir_locations = []
     if doi := paper_obj.doi:

--- a/src/RSEF/object_creator/create_metadata_obj.py
+++ b/src/RSEF/object_creator/create_metadata_obj.py
@@ -8,7 +8,6 @@ from ..utils.regex import (
 )
 import logging
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 
@@ -40,8 +39,7 @@ def doi_to_metadataObj(doi):
             return None
         
         if oa_meta is None:
-            log.debug("No meta")
-            
+            log.info("No meta")
         titL = safe_dic(oa_meta, "title")
         doi = str_to_doiID(safe_dic(oa_meta, "doi"))
         arxiv = extract_arxivID(oa_meta)

--- a/src/RSEF/object_creator/downloaded_to_paperObj.py
+++ b/src/RSEF/object_creator/downloaded_to_paperObj.py
@@ -8,6 +8,7 @@ from ..extraction.paper_obj import PaperObj
 from ..object_creator.create_downloadedObj import downloadedDic_to_downloadedObj, save_dict_to_json
 from ..object_creator.implementation_url import ImplementationUrl
 
+log = logging.getLogger(__name__)
 
 def downloaded_to_paperObj(downloadedObj):
     """
@@ -50,8 +51,7 @@ def downloaded_to_paperObj(downloadedObj):
             file_path=file_path
         )
     except Exception as e:
-        print(str(e))
-        print("Error while trying to read from the pdf")
+        log.error("Error while trying to read from the pdf: ", str(e))
 
 
 def dwnldd_obj_to_paper_dic(downloaded_obj):
@@ -132,17 +132,17 @@ def paperObj_ppDict(paper):
     try:
         if paper is not None:
             if paper.doi is None:
-                logging.warning(f"This paper does not have a doi, created a fake ID for {paper.title}")
+                log.warning(f"This paper does not have a doi, created a fake ID for {paper.title}")
                 paper.doi = BACKUP_ID
                 ans = {str(BACKUP_ID): paper.to_dict()}
                 BACKUP_ID += 1
                 return ans
             return {paper.doi: paper.to_dict()}
         else:
-            logging.debug("paper is None; cannot process.")
+            log.info("paper is None; cannot process.")
             return None
     except Exception as e:
-        logging.error("An error occurred while processing paper with DOI %s: %s", paper.doi, str(e))
+        log.error("An error occurred while processing paper with DOI %s: %s", paper.doi, str(e))
 
 def safe_dic(dic, key):
     try:

--- a/src/RSEF/object_creator/paper_to_directionality.py
+++ b/src/RSEF/object_creator/paper_to_directionality.py
@@ -6,7 +6,6 @@ from ..modelling.zenodo_bidirectionality import is_it_bidir as zenodo_is_it_bidi
 from ..modelling.unidirectionality import is_repo_unidir
 import logging
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 
@@ -28,21 +27,21 @@ def _get_identifier(paper):
     identifier
     """
     if not paper:
-        log.error("Paper Object is None")
+        log.info("Paper Object is None")
         return None
     if paper.doi and paper.doi != "0":
         return paper.doi
     elif paper.arxiv:
         return paper.arxiv
     else:
-        log.error("Paper Object Has no identifier to use")
+        log.debug("Paper Object Has no identifier to use")
         return None
 
 
 def check_paper_directionality(paper, directionality, output_dir):
     result = {}
     if not (iden := _get_identifier(paper)):
-        log.error(
+        log.info(
             "check_paper_directionality: No identifier found for this paper")
         return None
     try:
@@ -108,7 +107,7 @@ def _git_check_directionality(paper, git_urls, directionality, iden, first_time,
         # Download repository from SOMEF
         repo_file = download_repo_metadata(url, output_dir)
         if not repo_file:
-            log.error(f"Issue while downloading the repository for {iden}")
+            log.info(f"Issue while downloading the repository for {iden}")
             continue
         # assessment of bidirectionality
         if directionality:

--- a/src/RSEF/object_creator/pipeline.py
+++ b/src/RSEF/object_creator/pipeline.py
@@ -10,7 +10,6 @@ import logging
 import json
 import os
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 
@@ -166,7 +165,7 @@ def multi_doi_pipeline(list_dois, output_dir, bidir=True, unidir=True):
             log.error(str(e))
         finally:
             log.info(f"Finished analyzing DOI: {doi}")
-            print("-------------------------------\n")
+            log.info("-------------------------------\n")
 
     return dict_to_json({'RSEF Output': result}, output_path=os.path.join(output_dir, "url_search_output.json"))
 

--- a/src/RSEF/output_analysis/analysis.py
+++ b/src/RSEF/output_analysis/analysis.py
@@ -1,9 +1,12 @@
-import json
 from collections import defaultdict
+import logging
+import json
+
+log = logging.getLogger(__name__)
 
 def output_analysis(rsef_output_path: str, output_summary_path: str):
     """Analyze the output of RSEF and save summary statistics to a JSON file."""
-    print("Starting RSEF Output Analysis...")
+    log.info("Starting RSEF Output Analysis...")
     
     # Load the JSON file
     try:
@@ -11,7 +14,7 @@ def output_analysis(rsef_output_path: str, output_summary_path: str):
             data = json.load(file)
             rsef_output = data.get('RSEF Output', [])
     except (FileNotFoundError, json.JSONDecodeError) as e:
-        print(f"Error reading file: {e}")
+        log.info(f"Error reading file: {e}")
         return
     
     # Ensure uniqueness of RSEF output
@@ -75,6 +78,6 @@ def output_analysis(rsef_output_path: str, output_summary_path: str):
     try:
         with open(output_summary_path, 'w', encoding="UTF-8") as outfile:
             json.dump(summary, outfile, indent=4)
-        print(f"Summary statistics saved to {output_summary_path}")
+        log.info(f"Summary statistics saved to {output_summary_path}")
     except IOError as e:
-        print(f"Error saving summary: {e}")
+        log.error(f"Error saving summary: {e}")

--- a/src/RSEF/repofrompaper/link_search.py
+++ b/src/RSEF/repofrompaper/link_search.py
@@ -20,7 +20,6 @@ def find_link_in_references(reference_numbers: List[str], references: Dict[str, 
             repo_links = find_repo_links(references[ref])
             if repo_links:
                 link = repo_links[0]
-                # print(f'Found {link} in references dictionary using {ref} reference number')
                 return link, ref
     return None, None
 
@@ -31,7 +30,6 @@ def find_link_in_footnotes(all_footnotes: List[str], footnotes: Dict[str, str]) 
     for f in all_footnotes:
         if f in footnotes:
             link = footnotes[f]
-            # print(f'Found {link} in footnotes dictionary using footnote {f}')
             return link, f
     return None, None
 


### PR DESCRIPTION
This PR adds a global logger which saves the logs to `"output/logs/"` folder.

The default logging level is set to `INFO`, for complete logs it can be easily changed to `DEBUG` when needed,