### PR TITLE
Logging & Output Format Fix

### DIFF
--- a/src/RSEF/extraction/paper_obj.py
+++ b/src/RSEF/extraction/paper_obj.py
@@ -186,7 +186,7 @@ class PaperObj:
             'arxiv': self._arxiv,
             'abstract': self._abstract,
             'publication_date': self.publication_date,
-            'authors': ", ".join(self.authors) if self.authors else "",
+            'authors': None if self.authors is None else (", ".join(self.authors) if isinstance(self.authors, list) else self.authors),
             'file_name': self._file_name,
             'file_path': self._file_path,
             'pdf_link': self.pdf_link

--- a/src/RSEF/object_creator/create_downloadedObj.py
+++ b/src/RSEF/object_creator/create_downloadedObj.py
@@ -231,7 +231,7 @@ def doi_to_downloadedJson(doi, output_dir):
     dict = doi_to_downloadedDic(doi, output_dir)
     output_path = output_dir + DOWNLOADED_PATH
     with open(output_path, 'w+') as out_file:
-        json.dump(dict, out_file, sort_keys=True, indent=4,
+        json.dump([dict], out_file, sort_keys=True, indent=4,
                   ensure_ascii=False)
     return output_path
 
@@ -422,9 +422,9 @@ def save_dict_to_json(obj, json_path):
         with open(json_path, 'w', encoding='utf-8', errors='ignore') as file:
             json.dump(json_data, file, indent=4, ensure_ascii=False)
 
-        log.info("Data successfully appended to file:", json_path)
+        log.info(f"Data successfully appended to file: {json_path}")
     except Exception as e:
-        log.error("Error appending JSON data to file:", e)
+        log.error(f"Error appending JSON data to file: {e}")
 
 
 def remove_empty_fields_from_file(file_path):

--- a/src/RSEF/object_creator/downloaded_to_paperObj.py
+++ b/src/RSEF/object_creator/downloaded_to_paperObj.py
@@ -94,7 +94,7 @@ def dwnlddDic_to_paper_dic(downloadeds_dic, output_path):
         dwnObj = downloadedDic_to_downloadedObj(obj)
         paper = downloaded_to_paperObj(dwnObj)
         count += 1
-        print("Processed %s, \n Total Processed: %s Papers" % (index, count))
+        log.info(f"Processed {index}, Total Processed: {count} Papers")
         save_dict_to_json(paper.to_dict(), output_path)
     return output_path
 


### PR DESCRIPTION
This PR is a quick bug fix for the following issues:
1. Output format of `download_metadata.json` file in the case of a single file download is not of type `list`, so when it is used as an input file for the `assess` command it breaks the program. This PR makes sure the output is a list.
2. Paper.to_dict() assumes authors is always a list, however in the case of one author the name string gets separated by commas. This PR adds a type check.
3. Old print lines that were replaced with log lines break the program when multiple strings are passed to it as parameters. This PR replaces those log lines with formatted strings.